### PR TITLE
enabling whitenoise package to preserve the Swagger UI once we go to production

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'housing_backend.apps.HousingBackendConfig',
     'scrape',
@@ -55,6 +56,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -161,6 +163,8 @@ USE_TZ = True
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/housing/static/'
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)

--- a/backend/backend/wsgi.py
+++ b/backend/backend/wsgi.py
@@ -16,6 +16,12 @@ from gevent import monkey; monkey.patch_all()
 
 patch_psycopg()
 
+from whitenoise.django import DjangoWhiteNoise
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
 
 application = Cling(get_wsgi_application())
+
+# WhiteNoise allows us to serve the Swagger static files directly from Django even when settings.py:DEBUG=False
+# This saves us the trouble of having to build a static files web server, though that would be a great long-term solution
+application = DjangoWhiteNoise(application)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -52,3 +52,4 @@ WebTest==2.0.25
 wheel==0.24.0
 gevent==1.2.1
 psycogreen
+whitenoise==3.3.0


### PR DESCRIPTION
This allows the Django app to be able to serve the Swagger static files even when we set DEBUG=False for production usage. If we didn't add this package to the app, then as soon as you switch DEBUG from True to False, the Swagger UI disappears and the http://service.civicpdx.org/housing pages look ugly as sin again.