### PR TITLE
Standardize rent model and endpoint field names, add ProdvCost population to loader

### DIFF
--- a/backend/housing_backend/loader.py
+++ b/backend/housing_backend/loader.py
@@ -66,7 +66,7 @@ def loadNeighborhoodRent(file):
         n.save()
         h.save()
         rent, _ = NeighborhoodRent.objects.get_or_create(
-                nh_id=n,
+                neighborhood=n,
                 housing_size=h,
                 rent_amt=row['NHM_Rent_Amt'],
                 year=ry,
@@ -144,6 +144,27 @@ def loadPopToolTip(file):
         this_tooltip.save()
 
 
+def loadProdVsCost(file):
+    """ load data into prod vs cost model """
+    df = pd.read_csv(file)
+
+    dframe = df.where((pd.notnull(df)), None)
+
+    for index, row in dframe.iterrows():
+        ry, _ = ReportYear.objects.get_or_create(year=row['ReportYear'])
+        n, _ = Neighborhood.objects.get_or_create(NP_ID=row['NP_ID'], name=row['Neighborhood'])
+
+        this_prodvscost = HousingProductionVsCost(        year=ry,
+                                                neighborhood=n,
+                                                single_unit_growth=row['%GrowthSFY_Stacked'],
+                                                multi_unit_growth=row['%GrowthMFY_Stacked'],
+                                                home_price_growth=row['%GrowthMedianHomePrice'],
+                                                rent_growth=row['%GrowthEffectiveRent'],
+                                                )
+
+        this_prodvscost.save()
+
+
 fileDemo = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/DemographicProfiles_w2015_Profiles_2-15-17.csv"
 fileNeighborhoods = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/NeighborhoodProfiles.csv"
 fileAfford = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/SoHAffordabilityDatabyNeighborhoodUpload.csv"
@@ -151,6 +172,7 @@ fileRent = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasou
 fileSupply = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/HousingSupplyAndPermits.csv"
 fileHHToolTips = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/hhToolTips.csv"
 filePopToolTips = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/popToolTips.csv"
+fileProdVsCost = "https://raw.githubusercontent.com/hackoregon/housing-backend/datasources/HousingStockandPrices.csv"
 
 # Load year and neighborhood first because loadAffordability depends on it
 loadDemoByYear(fileDemo)
@@ -162,3 +184,4 @@ loadNeighborhoodRent(fileRent)
 loadHousingSupplyandPermits(fileSupply)
 loadHHToolTip(fileHHToolTips)
 loadPopToolTip(filePopToolTips)
+loadProdVsCost(fileProdVsCost)

--- a/backend/housing_backend/loader.py
+++ b/backend/housing_backend/loader.py
@@ -56,7 +56,10 @@ def loadDemoByYear(file):
             demo_by_year.save()
 
 def loadNeighborhoodRent(file):
-    dframe = pd.read_csv(file)
+    df = pd.read_csv(file)
+
+    # Convert NaN values to None for db insert
+    dframe = df.where((pd.notnull(df)), None)
 
     for index, row in dframe.iterrows():
         ry, _ = ReportYear.objects.get_or_create(year=row['NHM_ReportYear'])
@@ -154,12 +157,15 @@ def loadProdVsCost(file):
         ry, _ = ReportYear.objects.get_or_create(year=row['ReportYear'])
         n, _ = Neighborhood.objects.get_or_create(NP_ID=row['NP_ID'], name=row['Neighborhood'])
 
-        this_prodvscost = HousingProductionVsCost(        year=ry,
+        this_prodvscost = HousingProductionVsCost(
+                                                year=ry,
                                                 neighborhood=n,
-                                                single_unit_growth=row['%GrowthSFY_Stacked'],
-                                                multi_unit_growth=row['%GrowthMFY_Stacked'],
-                                                home_price_growth=row['%GrowthMedianHomePrice'],
-                                                rent_growth=row['%GrowthEffectiveRent'],
+                                                weighting_factor = row['TotalUnits(WeightingFactor)'],
+                                                single_unit_growth=row['Weighted_%GrowthSFYUnitsStacked'],
+                                                multi_unit_growth=row['Weighted_%GrowthMFYUnitsStacked'],
+                                                home_price_growth=row['Weighted_%GrowthMedianHomePrice'],
+                                                rent_growth=row['Weighted_%GrowthRent'],
+                                                msa_growth=row['MSA_%Growth']
                                                 )
 
         this_prodvscost.save()

--- a/backend/housing_backend/models.py
+++ b/backend/housing_backend/models.py
@@ -26,7 +26,7 @@ class Affordable(models.Model):
 
 
 class NeighborhoodRent(models.Model):
-    nh_id = models.ForeignKey('Neighborhood', on_delete=models.CASCADE)
+    neighborhood = models.ForeignKey('Neighborhood', on_delete=models.CASCADE)
     housing_size = models.ForeignKey('HousingSize', on_delete=models.CASCADE)
     rent_amt = models.IntegerField(default=0)
     year = models.ForeignKey('ReportYear', on_delete=models.CASCADE, help_text='Year for this rent sample', null=True)
@@ -121,10 +121,10 @@ class HousingProductionVsCost(models.Model):
 
     year = models.ForeignKey('ReportYear', on_delete=models.CASCADE)
     neighborhood = models.ForeignKey('Neighborhood', on_delete=models.CASCADE, help_text='Neighborhood by census tract')
-    single_unit_growth = models.FloatField(help_text="Single-family unit percent growth vs previous year")
-    multi_unit_growth = models.FloatField(help_text="Multi-family unit percent growth vs previous year")
-    home_price_growth = models.FloatField(help_text="Home price percent growth vs previous year")
-    rent_growth = models.FloatField(help_text="Rent percent growth vs previous year")
+    single_unit_growth = models.FloatField(null=True, help_text="Single-family unit percent growth vs previous year")
+    multi_unit_growth = models.FloatField(null=True, help_text="Multi-family unit percent growth vs previous year")
+    home_price_growth = models.FloatField(null=True, help_text="Home price percent growth vs previous year")
+    rent_growth = models.FloatField(null=True, help_text="Rent percent growth vs previous year")
 
 
 class HHToolTip(models.Model):

--- a/backend/housing_backend/models.py
+++ b/backend/housing_backend/models.py
@@ -28,7 +28,7 @@ class Affordable(models.Model):
 class NeighborhoodRent(models.Model):
     neighborhood = models.ForeignKey('Neighborhood', on_delete=models.CASCADE)
     housing_size = models.ForeignKey('HousingSize', on_delete=models.CASCADE)
-    rent_amt = models.IntegerField(default=0)
+    rent_amt = models.IntegerField(default=0, null=True)
     year = models.ForeignKey('ReportYear', on_delete=models.CASCADE, help_text='Year for this rent sample', null=True)
     
    
@@ -121,10 +121,14 @@ class HousingProductionVsCost(models.Model):
 
     year = models.ForeignKey('ReportYear', on_delete=models.CASCADE)
     neighborhood = models.ForeignKey('Neighborhood', on_delete=models.CASCADE, help_text='Neighborhood by census tract')
-    single_unit_growth = models.FloatField(null=True, help_text="Single-family unit percent growth vs previous year")
-    multi_unit_growth = models.FloatField(null=True, help_text="Multi-family unit percent growth vs previous year")
+    weighting_factor = models.IntegerField(null=True, help_text="Total units per neighborhood per report year")
+    single_unit_growth = models.FloatField(null=True,
+                                           help_text="Single-family unit percent growth vs previous year * total units ")
+    multi_unit_growth = models.FloatField(null=True,
+                                          help_text="Multi-family unit percent growth vs previous year * total units")
     home_price_growth = models.FloatField(null=True, help_text="Home price percent growth vs previous year")
     rent_growth = models.FloatField(null=True, help_text="Rent percent growth vs previous year")
+    msa_growth = models.FloatField(null=True, help_text="Metropolitan percentage growth in population")
 
 
 class HHToolTip(models.Model):

--- a/backend/housing_backend/serializers.py
+++ b/backend/housing_backend/serializers.py
@@ -40,7 +40,9 @@ class ProdVsCostSerializer(serializers.ModelSerializer):
                 'single_unit_growth',
                 'multi_unit_growth',
                 'home_price_growth',
-                'rent_growth'
+                'rent_growth',
+                'msa_growth',
+                'weighting_factor'
                 )
 
 

--- a/backend/housing_backend/serializers.py
+++ b/backend/housing_backend/serializers.py
@@ -17,12 +17,12 @@ class AffordableSerializer(serializers.ModelSerializer):
 class RentSerializer(serializers.ModelSerializer):
     year = serializers.IntegerField(source='year.year', read_only=True)
     housing_size = serializers.CharField(source='housing_size.household_type', read_only=True)
-    nh_id = serializers.IntegerField(source='nh_id.NP_ID', read_only=True)
-    nh_name = serializers.CharField(source='nh_id.name', read_only=True)
+    NP_ID = serializers.IntegerField(source='neighborhood.NP_ID', read_only=True)
+    neighborhood = serializers.CharField(source='neighborhood.name', read_only=True)
 
     class Meta:
         model = NeighborhoodRent
-        fields = ('year', 'rent_amt', 'housing_size', 'nh_id', 'nh_name')
+        fields = ('year', 'rent_amt', 'housing_size', 'NP_ID', 'neighborhood')
         depth = 1
 
 


### PR DESCRIPTION
This will require a db migration since some of the field names and attributes have changed.

After the migration, we can manually populate the HousingProductionVsCost model by extracting the function from the loader and running it manually.