### PR TITLE
Cleanup travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,27 @@ branches:
   - wiki
 services:
   - docker
-env:
-  global:
-    - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
-    - DOCKER_COMPOSE_VERSION=1.10.0
-before_install:
+# env:
+#   global:
+#     - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
+#     - DOCKER_COMPOSE_VERSION=1.10.0
+# before_install:
     # list docker-engine versions
-    - apt-cache madison docker-engine
+    # - apt-cache madison docker-engine
     # upgrade docker-engine to specific version
-    - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+    # - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
     # reinstall docker-compose at specific version
-    - sudo rm -f /usr/local/bin/docker-compose
-    - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-    - chmod +x ./docker-compose
-    - sudo mv ./docker-compose /usr/local/bin
+    # - sudo rm -f /usr/local/bin/docker-compose
+    # - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    # - chmod +x ./docker-compose
+    # - sudo mv ./docker-compose /usr/local/bin
 install:
   - pip install --upgrade --user awscli
 before_script:
   - ./backend/bin/getconfig.sh
 script:
-  - docker version
-  - /usr/local/bin/docker-compose version
+  # - docker version
+  # - /usr/local/bin/docker-compose version
   - './backend/bin/test-proj.sh -t'
 after_success:
   - ./backend/bin/docker-push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,11 @@ branches:
   - wiki
 services:
   - docker
-# env:
-#   global:
-#     - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
-#     - DOCKER_COMPOSE_VERSION=1.10.0
-# before_install:
-    # list docker-engine versions
-    # - apt-cache madison docker-engine
-    # upgrade docker-engine to specific version
-    # - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
-    # reinstall docker-compose at specific version
-    # - sudo rm -f /usr/local/bin/docker-compose
-    # - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-    # - chmod +x ./docker-compose
-    # - sudo mv ./docker-compose /usr/local/bin
 install:
   - pip install --upgrade --user awscli
 before_script:
   - ./backend/bin/getconfig.sh
 script:
-  # - docker version
-  # - /usr/local/bin/docker-compose version
   - './backend/bin/test-proj.sh -t'
 after_success:
   - ./backend/bin/docker-push.sh


### PR DESCRIPTION
Get rid of all the `docker` installation stuff that's no longer needed in today's Travis environment.